### PR TITLE
Use jwilder/nginx-proxy to fix gateway timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,13 @@ services:
       POSTGRES_USER: dhis
       POSTGRES_PASSWORD: dhis
   gateway:
-    image: "nginx:alpine"
+    image: "jwilder/nginx-proxy:alpine"
     restart: always
     ports:
       - "${DHIS2_CORE_PORT}:80"
     volumes:
       - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./.apps:/data/apps:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
 volumes:
   datadb:


### PR DESCRIPTION
https://github.com/jwilder/nginx-proxy

This is to fix the gateway not being able to route traffic to the dhis2-core container, without having to restart the gateway after the other two containers have started.